### PR TITLE
Clone SVT state on reset

### DIFF
--- a/intersim/envs/simulator.py
+++ b/intersim/envs/simulator.py
@@ -441,7 +441,7 @@ class InteractionSimulator(gym.Env):
             info (dict): diagnostic information useful for debugging
         """
 
-        self._state = self._svt.state0
+        self._state = self._svt.state0.clone()
         self._ind = 0
         self._exceeded = torch.tensor([False] * self._nv)
         self._graph.update_graph(self.projected_state)


### PR DESCRIPTION
Previous code would override SVT during simulation, making resets ineffective.